### PR TITLE
波括弧と構造体の修正

### DIFF
--- a/CNN2.c
+++ b/CNN2.c
@@ -18,17 +18,17 @@ typedef struct edge {        /* 一本のedge */
 
 typedef struct nodevec {     /* nodeの縦方向のカタマリ */
     Node* node;
-    Layer* next;
+    struct Layer* next;
 } Layer;
 
 typedef struct Layer_vec {   /* "nodeの縦方向のカタマリ" の横方向のカタマリ */
     Layer* layer;
-    Layer_vec* next;
+    struct Layer_vec* next;
 } Layer_vec;
 
 typedef struct edgevec {     /* "edgeの縦方向のカタマリ" の横方向のカタマリ */
     Edge** edge;
-    Edge_layer* next;
+    struct Edge_layer* next;
 } Edge_layer;
 
 

--- a/CNN2.c
+++ b/CNN2.c
@@ -16,7 +16,7 @@ typedef struct edge {        /* 一本のedge */
     float weight;
 } Edge;
 
-typedef struct nodevec {     /* nodeの縦方向のカタマリ */
+typedef struct Layer {     /* nodeの縦方向のカタマリ */
     Node* node;
     struct Layer* next;
 } Layer;

--- a/CNN2.c
+++ b/CNN2.c
@@ -6,27 +6,27 @@
 #include <stdlib.h>
 
 
-typedef struct node{        /* 一つのnode */
+typedef struct node {        /* 一つのnode */
     float value;
 } Node;
 
-typedef struct edge{        /* 一本のedge */
+typedef struct edge {        /* 一本のedge */
     Node* lhs;            /* nodeのアドレスを入れる場所 */
     Node* rhs;            /* nodeのアドレスを入れる場所 */
     float weight;
 } Edge;
 
-typedef struct nodevec{     /* nodeの縦方向のカタマリ */
+typedef struct nodevec {     /* nodeの縦方向のカタマリ */
     Node* node;
     Layer* next;
 } Layer;
 
-typedef struct Layer_vec{   /* "nodeの縦方向のカタマリ" の横方向のカタマリ */
+typedef struct Layer_vec {   /* "nodeの縦方向のカタマリ" の横方向のカタマリ */
     Layer* layer;
     Layer_vec* next;
 } Layer_vec;
 
-typedef struct edgevec{     /* "edgeの縦方向のカタマリ" の横方向のカタマリ */
+typedef struct edgevec {     /* "edgeの縦方向のカタマリ" の横方向のカタマリ */
     Edge** edge;
     Edge_layer* next;
 } Edge_layer;

--- a/CNN2.c
+++ b/CNN2.c
@@ -28,7 +28,7 @@ typedef struct Layer_vec {   /* "nodeの縦方向のカタマリ" の横方向�
 
 typedef struct edgevec {     /* "edgeの縦方向のカタマリ" の横方向のカタマリ */
     Edge** edge;
-    struct Edge_layer* next;
+    struct edgevec* next;
 } Edge_layer;
 
 


### PR DESCRIPTION
- 波括弧
    - 開き波括弧の前にはスペースを開けがち（[Google C++ スタイルガイド](https://ttsuki.github.io/styleguide/cppguide.ja.html#Namespaces)参照）
- 構造体
    - typedef の機能は `struct A { …` としたときは型名として `struct A` を使わないといけないところ，`struct A {…} B ` することで `B` という名前を使うこと．構造体宣言中はまだ宣言していないので新しい名前 `B` が使えないため，中では `struct A` を使う必要がある．あと，`A`と`B`の名前は揃えがち．
```C
typedef struct Layer_vec {
    Layer* layer;
    struct Layer_vec* next; // 先頭に struct をつける
} Layer_vec;
```